### PR TITLE
add #include <stdio.h>

### DIFF
--- a/src/examples/read-write-send.cpp
+++ b/src/examples/read-write-send.cpp
@@ -7,6 +7,7 @@
  */
 
 #include <stdlib.h>
+#include <stdio.h>
 #include <unistd.h>
 #include <cassert>
 

--- a/src/examples/send-performance.cpp
+++ b/src/examples/send-performance.cpp
@@ -7,6 +7,7 @@
  */
 
 #include <stdlib.h>
+#include <stdio.h>
 #include <unistd.h>
 #include <math.h>
 #include <time.h>


### PR DESCRIPTION
I think the #include <stdio.h> should be added to these two examples :)

these maybe unnacessary for the latest compiler, but I'm trying to use it on 
Linux version 2.6.32-220.el6.x86_64 (mockbuild@x86-004.build.bos.redhat.com) (gcc version 4.4.5 20110214 (Red Hat 4.4.5-6) (GCC) )