### PR TITLE
Restrict range of sequence number to 24 bits,

### DIFF
--- a/src/infinity/queues/QueuePair.cpp
+++ b/src/infinity/queues/QueuePair.cpp
@@ -67,7 +67,8 @@ QueuePair::QueuePair(infinity::core::Context* context) :
 	INFINITY_ASSERT(returnValue == 0, "[INFINITY][QUEUES][QUEUEPAIR] Cannot transition to INIT state.\n");
 
 	std::random_device randomGenerator;
-	this->sequenceNumber = randomGenerator();
+        std::uniform_int_distribution<int> range(0, 1<<24);
+        this->sequenceNumber = range(randomGenerator);
 
 	this->userData = NULL;
 	this->userDataSize = 0;


### PR DESCRIPTION
Hi Claude,

on my Centos 7 machines, I see

  kernel: infiniband mlx4_0: _ib_modify_qp rq_psn overflow, masking to 24 bits

in the logs. This patch fixes the issue for me.